### PR TITLE
Add support for Kuromoji tokenizer/filter factories from extension module

### DIFF
--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseBaseFormFilterFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseBaseFormFilterFactory.java
@@ -31,6 +31,7 @@ import org.opensearch.index.analysis.TokenFilterFactory;
 public class JapaneseBaseFormFilterFactory extends AbstractTokenFilterFactory {
 
     private static final String[] FACTORIES = new String[] { //
+            "org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiBaseFormFilterFactory", //
             "org.opensearch.index.analysis.KuromojiBaseFormFilterFactory" };
 
     private TokenFilterFactory tokenFilterFactory = null;

--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseIterationMarkCharFilterFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseIterationMarkCharFilterFactory.java
@@ -31,6 +31,7 @@ import org.opensearch.index.analysis.CharFilterFactory;
 public class JapaneseIterationMarkCharFilterFactory extends AbstractCharFilterFactory {
 
     private static final String[] FACTORIES = new String[] { //
+            "org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiIterationMarkCharFilterFactory", //
             "org.opensearch.index.analysis.KuromojiIterationMarkCharFilterFactory" };
 
     private CharFilterFactory charFilterFactory = null;

--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseKatakanaStemmerFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseKatakanaStemmerFactory.java
@@ -31,6 +31,7 @@ import org.opensearch.index.analysis.TokenFilterFactory;
 public class JapaneseKatakanaStemmerFactory extends AbstractTokenFilterFactory {
 
     private static final String[] FACTORIES = new String[] { //
+            "org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiKatakanaStemmerFactory", //
             "org.opensearch.index.analysis.KuromojiKatakanaStemmerFactory" };
 
     private TokenFilterFactory tokenFilterFactory;

--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapanesePartOfSpeechFilterFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapanesePartOfSpeechFilterFactory.java
@@ -31,6 +31,7 @@ import org.opensearch.index.analysis.TokenFilterFactory;
 public class JapanesePartOfSpeechFilterFactory extends AbstractTokenFilterFactory {
 
     private static final String[] FACTORIES = new String[] { //
+            "org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiPartOfSpeechFilterFactory", //
             "org.opensearch.index.analysis.KuromojiPartOfSpeechFilterFactory" };
 
     private TokenFilterFactory tokenFilterFactory = null;

--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseReadingFormFilterFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseReadingFormFilterFactory.java
@@ -31,6 +31,7 @@ import org.opensearch.index.analysis.TokenFilterFactory;
 public class JapaneseReadingFormFilterFactory extends AbstractTokenFilterFactory {
 
     private static final String[] FACTORIES = new String[] { //
+            "org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiReadingFormFilterFactory", //
             "org.opensearch.index.analysis.KuromojiReadingFormFilterFactory" };
 
     private TokenFilterFactory tokenFilterFactory = null;

--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseTokenizerFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/JapaneseTokenizerFactory.java
@@ -32,6 +32,7 @@ import org.opensearch.index.analysis.TokenizerFactory;
 public class JapaneseTokenizerFactory extends AbstractTokenizerFactory {
 
     private static final String[] FACTORIES = new String[] { //
+            "org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiTokenizerFactory", //
             "org.opensearch.index.analysis.KuromojiTokenizerFactory" };
 
     private TokenizerFactory tokenizerFactory = null;

--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/ReloadableJapaneseTokenizerFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/ReloadableJapaneseTokenizerFactory.java
@@ -33,6 +33,7 @@ import org.opensearch.index.analysis.TokenizerFactory;
 public class ReloadableJapaneseTokenizerFactory extends AbstractTokenizerFactory {
 
     private static final String[] FACTORIES = new String[] { //
+            "org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiTokenizerFactory", //
             "org.opensearch.index.analysis.KuromojiTokenizerFactory" };
 
     private TokenizerFactory tokenizerFactory = null;


### PR DESCRIPTION
This pull request enhances the Japanese analysis components by adding support for custom Kuromoji factories from the `org.codelibs.opensearch.extension` package. These changes ensure better extensibility and compatibility with extended Kuromoji functionalities.

### Enhancements to Japanese analysis components:

* [`JapaneseBaseFormFilterFactory`](diffhunk://#diff-3b48e8fd586bb804ed1bf0f23f45c5c7feb5461a0aafd7e0bb4426619fa83057R34): Added support for `org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiBaseFormFilterFactory` to the list of available factories.
* [`JapaneseIterationMarkCharFilterFactory`](diffhunk://#diff-feb0270cce82b43626042dc99c7ba5efb7c1cf76e8a3e3ae09fa15627cd9ae5dR34): Included `org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiIterationMarkCharFilterFactory` in the factory options.
* [`JapaneseKatakanaStemmerFactory`](diffhunk://#diff-a839cbb461fd3fa0aab0329fd97dd027a2ed2aa2cda61dbf9cfa2232754bb926R34): Added `org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiKatakanaStemmerFactory` to the supported factories.
* [`JapanesePartOfSpeechFilterFactory`](diffhunk://#diff-d49cf1d54c15e5762225d60d45a29e3ae68a3870c99a738a1ad1ac9ce9cff707R34): Extended the factory list with `org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiPartOfSpeechFilterFactory`.
* [`JapaneseReadingFormFilterFactory`](diffhunk://#diff-b34a7817afb2353a59b8114b85d5ea5886224e72d0506953e5cb05b61510956dR34): Updated to include `org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiReadingFormFilterFactory` as a factory option.

### Tokenizer factory updates:

* [`JapaneseTokenizerFactory`](diffhunk://#diff-ef4bcbe4bc90340284e1dcb1fde208efb0a025016e120fa6a986feb1885addc5R35): Added `org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiTokenizerFactory` to the tokenizer factory list.
* [`ReloadableJapaneseTokenizerFactory`](diffhunk://#diff-ea12441d54307b2b9c38eac4284cc626b7163fd7b5cd4f24cb11a16f32fee5a3R36): Included `org.codelibs.opensearch.extension.kuromoji.index.analysis.KuromojiTokenizerFactory` in the available tokenizer factories.