### PR TITLE
Remove deprecation warning from ReloadableJapaneseTokenizerFactory

### DIFF
--- a/src/main/java/org/codelibs/opensearch/fess/index/analysis/ReloadableJapaneseTokenizerFactory.java
+++ b/src/main/java/org/codelibs/opensearch/fess/index/analysis/ReloadableJapaneseTokenizerFactory.java
@@ -42,8 +42,6 @@ public class ReloadableJapaneseTokenizerFactory extends AbstractTokenizerFactory
             final Settings settings, final FessAnalysisService fessAnalysisService) {
         super(indexSettings, settings, name);
 
-        logger.warn("ReloadableJapaneseTokenizerFactory is deprecated. Use JapaneseTokenizerFactory instead.");
-
         for (final String factoryClass : FACTORIES) {
             final Class<?> tokenizerFactoryClass = fessAnalysisService.loadClass(factoryClass);
             if (tokenizerFactoryClass != null) {


### PR DESCRIPTION
This pull request removes the deprecation warning log message from the ReloadableJapaneseTokenizerFactory class. The warning advised users to switch to JapaneseTokenizerFactory, but it has now been removed, possibly to reduce log noise or because the deprecation notice is no longer relevant.
