### PR TITLE
Bump plugin and dependencies to OpenSearch 3.1.0 and Lucene 10.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-fess</artifactId>
-	<version>3.0.2-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for Fess, enabling custom analyzers, tokenizers, and filters for OpenSearch to enhance full-text search capabilities and support Fess-specific linguistic processing.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-fess</url>
@@ -36,11 +36,11 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.0.0</opensearch.version>
-		<opensearch.runner.version>3.0.0.0</opensearch.runner.version>
+		<opensearch.version>3.1.0</opensearch.version>
+		<opensearch.runner.version>3.1.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.fess.FessAnalysisPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.1.0</lucene.version>
+		<lucene.version>10.2.1</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
This pull request updates the version numbers and dependencies in the `pom.xml` file to align with the latest releases of OpenSearch and Lucene. These changes ensure compatibility with newer versions and improve functionality.

Version updates:

* Updated the project version from `3.0.2-SNAPSHOT` to `3.1.0-SNAPSHOT` to reflect the latest development iteration. (`pom.xml`, [pom.xmlL7-R7](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7))
* Updated OpenSearch and OpenSearch Runner versions from `3.0.0` to `3.1.0` and `3.0.0.0` to `3.1.0.0`, respectively, ensuring compatibility with the latest OpenSearch framework. (`pom.xml`, [pom.xmlL39-R43](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R43))

Dependency updates:

* Upgraded Lucene version from `10.1.0` to `10.2.1` to leverage improvements and bug fixes in the latest release. (`pom.xml`, [pom.xmlL39-R43](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R43))