### PR TITLE
Update OpenSearch to 3.3.0 and Lucene to 10.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-fess</artifactId>
-	<version>3.2.1-SNAPSHOT</version>
+	<version>3.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for Fess, enabling custom analyzers, tokenizers, and filters for OpenSearch to enhance full-text search capabilities and support Fess-specific linguistic processing.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-fess</url>
@@ -36,11 +36,11 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.2.0</opensearch.version>
-		<opensearch.runner.version>3.2.0.0</opensearch.runner.version>
+		<opensearch.version>3.3.0</opensearch.version>
+		<opensearch.runner.version>3.3.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.fess.FessAnalysisPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.2.2</lucene.version>
+		<lucene.version>10.3.1</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
## Summary

This PR updates the plugin to support OpenSearch 3.3.0 and Lucene 10.3.1, ensuring compatibility with the latest versions of these dependencies.

## Changes Made

- Updated OpenSearch dependency from 3.2.0 to 3.3.0
- Updated OpenSearch Runner from 3.2.0.0 to 3.3.0.0
- Updated Lucene dependency from 10.2.2 to 10.3.1
- Bumped plugin version from 3.2.1-SNAPSHOT to 3.3.0-SNAPSHOT

## Testing

- Build verification: `mvn compile`
- Unit tests: `mvn test`
- License check: `mvn license:check`
- Package build: `mvn package`

## Breaking Changes

None. This is a dependency version update that maintains API compatibility.

## Additional Notes

This update aligns the plugin with the latest stable releases of OpenSearch and Lucene, providing bug fixes, performance improvements, and new features available in these versions.