### PR TITLE
chore: Update OpenSearch to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.3.0</opensearch.version>
-		<opensearch.runner.version>3.3.0.0</opensearch.runner.version>
+		<opensearch.version>3.3.2</opensearch.version>
+		<opensearch.runner.version>3.3.2.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.fess.FessAnalysisPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<lucene.version>10.3.1</lucene.version>


### PR DESCRIPTION
## Summary

This PR updates the OpenSearch dependency from version 3.3.0 to 3.3.2, along with the corresponding runner version update from 3.3.0.0 to 3.3.2.0. This ensures the plugin remains compatible with the latest OpenSearch release.

## Changes Made

- Updated `opensearch.version` property from 3.3.0 to 3.3.2 in pom.xml
- Updated `opensearch.runner.version` property from 3.3.0.0 to 3.3.2.0 in pom.xml

## Testing

This is a dependency version update. The existing test suite should validate compatibility:
- Build verification: `mvn compile`
- Unit tests: `mvn test`
- Full package build: `mvn package`

## Breaking Changes

None expected. This is a minor version update that should maintain backward compatibility.

## Additional Notes

- This update aligns with OpenSearch 3.3.2 release
- Lucene version (10.3.1) remains unchanged
- No code changes required, only dependency version updates