### PR TITLE
chore: Update OpenSearch to 3.4.0 and Lucene to 10.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-fess</artifactId>
-	<version>3.3.2-SNAPSHOT</version>
+	<version>3.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for Fess, enabling custom analyzers, tokenizers, and filters for OpenSearch to enhance full-text search capabilities and support Fess-specific linguistic processing.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-fess</url>
@@ -36,11 +36,11 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.3.2</opensearch.version>
-		<opensearch.runner.version>3.3.2.0</opensearch.runner.version>
+		<opensearch.version>3.4.0</opensearch.version>
+		<opensearch.runner.version>3.4.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.fess.FessAnalysisPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.3.1</lucene.version>
+		<lucene.version>10.3.2</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -19,9 +19,6 @@
 		<dependencySet>
 			<useProjectArtifact>true</useProjectArtifact>
 			<useTransitiveFiltering>true</useTransitiveFiltering>
-			<excludes>
-				<exclude>org.codelibs.opensearch:opensearch-engine-server</exclude>
-			</excludes>
 		</dependencySet>
 	</dependencySets>
 </assembly>


### PR DESCRIPTION
## Summary
Update OpenSearch to version 3.4.0 and Lucene to version 10.3.2.

## Changes Made
- Update `opensearch.version` from 3.3.2 to 3.4.0
- Update `opensearch.runner.version` from 3.3.2.0 to 3.4.0.0
- Update `lucene.version` from 10.3.1 to 10.3.2
- Update project version to 3.4.0-SNAPSHOT
- Remove unnecessary exclude for `opensearch-engine-server` in plugin.xml assembly

## Testing
- Build and test with updated dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)