### PR TITLE
chore: Update OpenSearch to 3.5.0 and Log4j to 2.25.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-fess</artifactId>
-	<version>3.4.1-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for Fess, enabling custom analyzers, tokenizers, and filters for OpenSearch to enhance full-text search capabilities and support Fess-specific linguistic processing.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-fess</url>
@@ -36,12 +36,12 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.4.0</opensearch.version>
-		<opensearch.runner.version>3.4.0.0</opensearch.runner.version>
+		<opensearch.version>3.5.0</opensearch.version>
+		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.fess.FessAnalysisPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<lucene.version>10.3.2</lucene.version>
-		<log4j.version>2.21.0</log4j.version>
+		<log4j.version>2.25.3</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>


### PR DESCRIPTION
## Summary
- Update OpenSearch version from 3.4.0 to 3.5.0
- Update OpenSearch Runner version from 3.4.0.0 to 3.5.0.0
- Update project version from 3.4.1-SNAPSHOT to 3.5.0-SNAPSHOT
- Update Log4j from 2.21.0 to 2.25.3

## Test plan
- [ ] Verify `mvn compile` succeeds
- [ ] Verify `mvn test` passes all tests
- [ ] Verify `mvn package` builds plugin JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)