### PR TITLE
chore: Update OpenSearch to 3.6.0 and Lucene to 10.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-fess</artifactId>
-	<version>3.5.1-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for Fess, enabling custom analyzers, tokenizers, and filters for OpenSearch to enhance full-text search capabilities and support Fess-specific linguistic processing.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-fess</url>
@@ -36,11 +36,11 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.5.0</opensearch.version>
-		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
+		<opensearch.version>3.6.0</opensearch.version>
+		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.fess.FessAnalysisPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.3.2</lucene.version>
+		<lucene.version>10.4.0</lucene.version>
 		<log4j.version>2.25.3</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
## Summary
Update dependency versions for OpenSearch 3.6.0 compatibility.

## Changes Made
- Bump project version from `3.5.1-SNAPSHOT` to `3.6.0-SNAPSHOT`
- Update OpenSearch from `3.5.0` to `3.6.0`
- Update OpenSearch Runner from `3.5.0.0` to `3.6.0.0`
- Update Lucene from `10.3.2` to `10.4.0`

## Testing
- Build and run tests with `mvn test` against updated dependencies

## Breaking Changes
- None expected — version alignment only