### PR TITLE
chore: Update OpenSearch to 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ A comprehensive analysis plugin for OpenSearch that provides custom analyzers, t
 - **Chinese Language Support**: Traditional Chinese character conversion and simplified Chinese tokenization
 - **System Index Management**: Automatic management of Fess-specific system indices
 - **Reloadable Configuration**: Support for dynamic Japanese tokenizer configuration reloading
-- **OpenSearch Integration**: Native integration with OpenSearch 3.2.0 and Lucene 10.2.2
+- **OpenSearch Integration**: Native integration with OpenSearch 3.7.0 and Lucene 10.4.0
 
 ## Tech Stack
 
 - **Java**: 21
-- **OpenSearch**: 3.2.0
-- **Apache Lucene**: 10.2.2
+- **OpenSearch**: 3.7.0
+- **Apache Lucene**: 10.4.0
 - **Build Tool**: Apache Maven 3.x
 - **Testing**: JUnit 4.13.2
 
@@ -28,7 +28,7 @@ A comprehensive analysis plugin for OpenSearch that provides custom analyzers, t
 ### Prerequisites
 
 - Java 21 or higher
-- OpenSearch 3.2.0 or compatible version
+- OpenSearch 3.7.0 or compatible version
 - Apache Maven 3.6+ (for building from source)
 
 ### Installation
@@ -36,7 +36,7 @@ A comprehensive analysis plugin for OpenSearch that provides custom analyzers, t
 #### Option 1: Install from Maven Repository
 
 ```bash
-$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs:opensearch-analysis-fess:3.2.0
+$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs:opensearch-analysis-fess:3.7.0
 ```
 
 #### Option 2: Build and Install from Source
@@ -50,7 +50,7 @@ cd opensearch-analysis-fess
 mvn clean package
 
 # Install the plugin
-$OPENSEARCH_HOME/bin/opensearch-plugin install file:///path/to/target/releases/opensearch-analysis-fess-3.2.0.jar
+$OPENSEARCH_HOME/bin/opensearch-plugin install file:///path/to/target/releases/opensearch-analysis-fess-3.7.0.jar
 ```
 
 ### Restart OpenSearch

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-fess</artifactId>
-	<version>3.6.1-SNAPSHOT</version>
+	<version>3.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for Fess, enabling custom analyzers, tokenizers, and filters for OpenSearch to enhance full-text search capabilities and support Fess-specific linguistic processing.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-fess</url>
@@ -36,8 +36,8 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.6.0</opensearch.version>
-		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
+		<opensearch.version>3.7.0</opensearch.version>
+		<opensearch.runner.version>3.7.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.fess.FessAnalysisPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<lucene.version>10.4.0</lucene.version>


### PR DESCRIPTION
## Summary
Upgrade the plugin to OpenSearch 3.7.0, following the same approach as the previous 3.6.0 update (#12).

## Changes Made
- Bump project version to `3.7.0-SNAPSHOT`
- Update `opensearch.version` from `3.6.0` to `3.7.0`
- Update `opensearch.runner.version` from `3.6.0.0` to `3.7.0.0`
- Keep `lucene.version` at `10.4.0` — OpenSearch 3.7.0 depends on the same Lucene version as 3.6.0 (verified against the OpenSearch 3.7.0 POM on Maven Central)
- Refresh stale version references in README.md (OpenSearch 3.2.0 / Lucene 10.2.2 → 3.7.0 / 10.4.0)

## Testing
- `mvn compile` — succeeds against OpenSearch 3.7.0
- `mvn test` — all 38 tests pass
- `mvn license:check` — no violations
- `mvn package` — plugin zip builds successfully (`opensearch-analysis-fess-3.7.0-SNAPSHOT.zip`)

## Breaking Changes
- None

## Additional Notes
- No source code changes were required; the plugin compiles and passes tests against 3.7.0 as-is.