### PR TITLE
build: attach sources and javadoc jars to release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
 						<goals>
-							<goal>jar</goal>
+							<goal>jar-no-fork</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -84,6 +84,14 @@
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>


### PR DESCRIPTION
## Summary
Release builds via `release:perform` did not produce sources and javadoc jars. This is the same issue fixed in codelibs/opensearch-runner@25c54af481a7f94409c4165647f5d1210d065ff6: the super POM release-profile that used to attach these artifacts is no longer available in current Maven versions, so the plugins must be configured explicitly.

## Changes Made
- Updated `maven-source-plugin` from 3.2.1 to 3.3.1 and switched the `attach-sources` execution from the `jar` goal to `jar-no-fork` to avoid re-forking the lifecycle during release builds
- Added an `attach-javadocs` execution with the `jar` goal to `maven-javadoc-plugin`, which previously had no execution and therefore never attached a javadoc jar

## Testing
- Ran `mvn -B -DskipTests package` and confirmed `target/` now contains the main jar plus `-sources.jar` and `-javadoc.jar` artifacts

## Breaking Changes
- None

## Additional Notes
- Mirrors codelibs/opensearch-runner#20 to keep release configuration consistent across CodeLibs projects